### PR TITLE
Arjun | Update 24 hour timers to auto-populate time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bahmni-carbon-ui",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Next generation ui components for OpenMRS and Bahmni built using the Carbon design system",
   "main": "dist/index.js",
   "author": "bahmni@thoughtworks.com",

--- a/src/components/DatePickerCarbon/DatePickerCarbon.jsx
+++ b/src/components/DatePickerCarbon/DatePickerCarbon.jsx
@@ -28,7 +28,7 @@ const DatePickerCarbon = (props) => {
   }
   let titleText = title && <Title text={title} isRequired={isRequired} />;
   return (
-    <div data-testid={testId || "datePicker"}>
+    <div data-testid={testId || "datePicker"} className="date-picker-carbon">
       <DatePicker
         datePickerType={datePickerType || "single"}
         onChange={onChange}

--- a/src/components/TimePicker/TimePicker.jsx
+++ b/src/components/TimePicker/TimePicker.jsx
@@ -36,7 +36,8 @@ const TimePickerCarbon = (props) => {
   }, [defaultTime]);
 
   const isValidTime = (newTime) => {
-    const timeRegex = /^((1[0-2]|0?[1-9]):[0-5][0-9])$/;
+    if (newTime === "Invalid date") return false;
+    const timeRegex = /^((1[0-2]|0?[1-9]):[0-5][0-9] (AM|PM))$/;
     if (timeRegex.test(newTime)) {
       return true;
     }
@@ -45,23 +46,30 @@ const TimePickerCarbon = (props) => {
 
   const handleChange = (e) => {
     const newTime = e.target.value;
-    const selectedTime =
-      newTime === "" ? "" : moment(newTime + period, "h:mm A");
-    if (isValidTime(newTime)) {
+    const selectedTime = moment(newTime + period, "hh:mm A").format("hh:mm A");
+    if (isValidTime(selectedTime)) {
       setWarning(false);
+      setTime(moment(selectedTime, "hh:mm A").format("hh:mm"));
+      if (
+        period !==
+        moment(selectedTime, "hh:mm A").format("hh:mm A").split(" ")[1]
+      )
+        setPeriod(
+          moment(selectedTime, "hh:mm A").format("hh:mm A").split(" ")[1]
+        );
     } else {
       setWarning(true);
+      setTime("");
     }
-    setTime(newTime);
     onChange(selectedTime);
   };
 
   const handlePeriod = (e) => {
     const newPeriod = e.target.value;
-    if (isValidTime(time)) {
+    const selectedTime = moment(time + newPeriod, "hh:mm A").format("hh:mm A");
+    if (isValidTime(selectedTime)) {
       setWarning(false);
       setPeriod(newPeriod);
-      const selectedTime = moment(time + newPeriod, "h:mm A");
       onChange(selectedTime);
     } else {
       setWarning(true);

--- a/src/components/TimePicker24Hour/TimePicker24Hour.jsx
+++ b/src/components/TimePicker24Hour/TimePicker24Hour.jsx
@@ -39,10 +39,7 @@ const TimePicker24Hour = (props) => {
 
   const handleChange = async (e) => {
     const displayTime = e.target.value;
-    console.log("displayTime = ", displayTime);
     const newTime = moment(displayTime, "HH:mm").format("HH:mm");
-    console.log("newTime = ", newTime);
-    console.log("momentized time = ", moment(newTime, "HH:mm").format("HH:mm"));
     if (isValidTime(newTime)) {
       setWarning(false);
       setTime(newTime);

--- a/src/components/TimePicker24Hour/TimePicker24Hour.jsx
+++ b/src/components/TimePicker24Hour/TimePicker24Hour.jsx
@@ -37,7 +37,7 @@ const TimePicker24Hour = (props) => {
     return false;
   };
 
-  const handleChange = async (e) => {
+  const handleChange = (e) => {
     const displayTime = e.target.value;
     const newTime = moment(displayTime, "HH:mm").format("HH:mm");
     if (isValidTime(newTime)) {

--- a/src/components/TimePicker24Hour/TimePicker24Hour.jsx
+++ b/src/components/TimePicker24Hour/TimePicker24Hour.jsx
@@ -29,6 +29,7 @@ const TimePicker24Hour = (props) => {
   }, [defaultTime]);
 
   const isValidTime = (newTime) => {
+    if (newTime === "Invalid date") return false;
     const timeRegex = /^([01][0-9]|2[0-3]):[0-5][0-9]$/;
     if (timeRegex.test(newTime)) {
       return true;
@@ -36,18 +37,19 @@ const TimePicker24Hour = (props) => {
     return false;
   };
 
-  const handleChange = (e) => {
+  const handleChange = async (e) => {
     const displayTime = e.target.value;
-    const newTime =
-      moment(displayTime, "HH:mm", true).format("HH:mm") !== "Invalid date"
-        ? moment(displayTime, "HH:mm", true).format("HH:mm")
-        : displayTime;
+    console.log("displayTime = ", displayTime);
+    const newTime = moment(displayTime, "HH:mm").format("HH:mm");
+    console.log("newTime = ", newTime);
+    console.log("momentized time = ", moment(newTime, "HH:mm").format("HH:mm"));
     if (isValidTime(newTime)) {
       setWarning(false);
+      setTime(newTime);
     } else {
       setWarning(true);
+      setTime("");
     }
-    setTime(newTime);
     onChange(newTime);
   };
 

--- a/src/components/TimePicker24Hour/TimePicker24Hour.stories.jsx
+++ b/src/components/TimePicker24Hour/TimePicker24Hour.stories.jsx
@@ -14,7 +14,7 @@ export const Primary = () => {
       isRequired={true}
       translationKey={"APPOINTMENT_TIME_FROM_LABEL"}
       defaultTranslationKey={"Start Time"}
-      defaultTime={moment()}
+      defaultTime={moment().format("HH:mm")}
     />
   );
 };


### PR DESCRIPTION
# Summary

This PR has changes to
- Auto-populate 24 hour timers without the user having to enter a colon (:)
- Update time displayed in 12 and 24 hour timers